### PR TITLE
Release for v0.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
 # Changelog
 
+## [v0.0.2](https://github.com/upamune/airule/compare/v0.0.1...v0.0.2) - 2025-04-14
+- Create LICENSE by @upamune in https://github.com/upamune/airule/pull/2
+- Refactor binary file check in preview.go by removing unnecessary content checks by @upamune in https://github.com/upamune/airule/pull/4
+
 ## [v0.0.1](https://github.com/upamune/airule/commits/v0.0.1) - 2025-04-14


### PR DESCRIPTION
This pull request is for the next release as v0.0.2 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.0.2 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.0.1" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Create LICENSE by @upamune in https://github.com/upamune/airule/pull/2
* Refactor binary file check in preview.go by removing unnecessary content checks by @upamune in https://github.com/upamune/airule/pull/4


**Full Changelog**: https://github.com/upamune/airule/compare/v0.0.1...v0.0.2