### PR TITLE
fix: Exclude base directory from parent directory checks in preservation logic

### DIFF
--- a/internal/copier/copier.go
+++ b/internal/copier/copier.go
@@ -80,10 +80,11 @@ func checkPreservationRecursiveWithBase(path, baseDir string, excludePatterns []
 	}
 
 	// 2. Check if any parent directory is hidden or matches exclude patterns
+	// But skip the base directory itself (the directory we're cleaning)
 	currentPath := path
 	for {
 		parent := filepath.Dir(currentPath)
-		if parent == currentPath || parent == "." || parent == "/" {
+		if parent == currentPath || parent == "." || parent == "/" || parent == baseDir {
 			break
 		}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - 親ディレクトリのチェック時に、ベースディレクトリを除外するよう改善されました。これにより、ベースディレクトリが保存条件の判定対象から外れます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->